### PR TITLE
logvisor: Make Module constructor constexpr

### DIFF
--- a/include/logvisor/logvisor.hpp
+++ b/include/logvisor/logvisor.hpp
@@ -207,7 +207,7 @@ class Module {
   }
 
 public:
-  Module(const char* modName) : m_modName(modName) {}
+  constexpr Module(const char* modName) : m_modName(modName) {}
 
   /**
    * @brief Route new log message to centralized ILogger


### PR DESCRIPTION
Allows the module instances to be constructed at compile time. Otherwise, this is technically a runtime static constructor when an instance is declared at file scope.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/logvisor/1)
<!-- Reviewable:end -->
