### PR TITLE
logvisor: Mark logvisorAbort as [[noreturn]]

### DIFF
--- a/include/logvisor/logvisor.hpp
+++ b/include/logvisor/logvisor.hpp
@@ -21,7 +21,7 @@ extern "C" void logvisorBp();
 
 namespace logvisor {
 
-void logvisorAbort();
+[[noreturn]] void logvisorAbort();
 
 #if _WIN32 && UNICODE
 #define LOG_UCS2 1

--- a/lib/logvisor.cpp
+++ b/lib/logvisor.cpp
@@ -116,7 +116,7 @@ void KillProcessTree() {
   }
 }
 
-void logvisorAbort() {
+[[noreturn]] void logvisorAbort() {
 #if !WINDOWS_STORE
   unsigned int i;
   void* stack[100];
@@ -167,13 +167,13 @@ void logvisorAbort() {
 }
 
 #elif defined(__SWITCH__)
-void logvisorAbort() { exit(1); }
+[[noreturn]] void logvisorAbort() { exit(1); }
 #else
 
 void KillProcessTree() {}
 
 #include <execinfo.h>
-void logvisorAbort() {
+[[noreturn]] void logvisorAbort() {
   void* array[128];
   size_t size = backtrace(array, 128);
 


### PR DESCRIPTION
All variants of logvisorAbort do what they say in their name -- abort. Given control isn't returned from this function, we can signify that it's a noreturn function

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/logvisor/5)
<!-- Reviewable:end -->
